### PR TITLE
Make double quote processor match first occurrence of ending quote

### DIFF
--- a/lib/improve_typography/processors/double_quotes.rb
+++ b/lib/improve_typography/processors/double_quotes.rb
@@ -1,7 +1,7 @@
 module ImproveTypography
   module Processors
     class DoubleQuotes < Processor
-      REGEXP = /["](.*)["]/i
+      REGEXP = /["](.*?)["]/i
 
       def call
         replace_double_quotes

--- a/test/improve_typography/processors/double_quotes_test.rb
+++ b/test/improve_typography/processors/double_quotes_test.rb
@@ -8,6 +8,7 @@ module ImproveTypography
       describe "do's" do
         it { DoubleQuotes.call('"so it is not authorless"').must_equal "#{double_quotes[0]}so it is not authorless#{double_quotes[1]}" }
         it { DoubleQuotes.call('"2 + 2 = 6"').must_equal "#{double_quotes[0]}2 + 2 = 6#{double_quotes[1]}" }
+        it { DoubleQuotes.call('"2 + 2 = 6" and "2 - 2 = 0"').must_equal "#{double_quotes[0]}2 + 2 = 6#{double_quotes[1]} and #{double_quotes[0]}2 - 2 = 0#{double_quotes[1]}" }
       end
 
       describe "dont's" do


### PR DESCRIPTION
Double quotes processor regexp should be non greedy, otherwise it will only match the last ending quote of a paragraph.