### PR TITLE
Quotes processors

### DIFF
--- a/lib/improve_typography/processors/double_quotes.rb
+++ b/lib/improve_typography/processors/double_quotes.rb
@@ -1,7 +1,7 @@
 module ImproveTypography
   module Processors
     class DoubleQuotes < Processor
-      REGEXP = /["](.*?)["]/i
+      REGEXP = /["“”](.*?)["“”]/i
 
       def call
         replace_double_quotes

--- a/lib/improve_typography/processors/single_quotes.rb
+++ b/lib/improve_typography/processors/single_quotes.rb
@@ -1,7 +1,7 @@
 module ImproveTypography
   module Processors
     class SingleQuotes < Processor
-      REGEXP = /['](.*)[']/i
+      REGEXP = /['’‘](.*?)['’‘](?!\w)/i
 
       def call
         replace_single_quotes

--- a/test/improve_typography/processors/double_quotes_test.rb
+++ b/test/improve_typography/processors/double_quotes_test.rb
@@ -9,6 +9,8 @@ module ImproveTypography
         it { DoubleQuotes.call('"so it is not authorless"').must_equal "#{double_quotes[0]}so it is not authorless#{double_quotes[1]}" }
         it { DoubleQuotes.call('"2 + 2 = 6"').must_equal "#{double_quotes[0]}2 + 2 = 6#{double_quotes[1]}" }
         it { DoubleQuotes.call('"2 + 2 = 6" and "2 - 2 = 0"').must_equal "#{double_quotes[0]}2 + 2 = 6#{double_quotes[1]} and #{double_quotes[0]}2 - 2 = 0#{double_quotes[1]}" }
+        it { DoubleQuotes.call('“2 + 2 = 6” and ”2 - 2 = 0”').must_equal "#{double_quotes[0]}2 + 2 = 6#{double_quotes[1]} and #{double_quotes[0]}2 - 2 = 0#{double_quotes[1]}" }
+        it { DoubleQuotes.call('”2 + 2 = 6” and ”2 - 2 = 0”').must_equal "#{double_quotes[0]}2 + 2 = 6#{double_quotes[1]} and #{double_quotes[0]}2 - 2 = 0#{double_quotes[1]}" }
       end
 
       describe "dont's" do

--- a/test/improve_typography/processors/single_quotes_test.rb
+++ b/test/improve_typography/processors/single_quotes_test.rb
@@ -7,8 +7,10 @@ module ImproveTypography
 
       describe "do's" do
         it { SingleQuotes.call("'so it is not authorless'").must_equal "#{single_quotes[0]}so it is not authorless#{single_quotes[1]}" }
-        it { SingleQuotes.call("'so it isn't authorless'").must_equal "#{single_quotes[0]}so it isn't authorless#{single_quotes[1]}" }
+        it { SingleQuotes.call("'so it isn't authorless' or 'it doesn't seem that way'").must_equal "#{single_quotes[0]}so it isn't authorless#{single_quotes[1]} or #{single_quotes[0]}it doesn't seem that way#{single_quotes[1]}" }
         it { SingleQuotes.call("'2 + 2 = 6'").must_equal "#{single_quotes[0]}2 + 2 = 6#{single_quotes[1]}" }
+        it { SingleQuotes.call("’2 + 2 = 6’ and ’1 + 1 = 99’").must_equal "#{single_quotes[0]}2 + 2 = 6#{single_quotes[1]} and #{single_quotes[0]}1 + 1 = 99#{single_quotes[1]}" }
+        it { SingleQuotes.call("‘2 + 2 = 6‘ and ‘1 + 1 = 99‘").must_equal "#{single_quotes[0]}2 + 2 = 6#{single_quotes[1]} and #{single_quotes[0]}1 + 1 = 99#{single_quotes[1]}" }
       end
 
       describe "dont's" do


### PR DESCRIPTION
Optimizes `DoubleQuotes` and `SingleQuotes` processors to handle cases with wrong use of curly quotes. Currently they both look only for straight quotes, which means they do not fix wrong use of curly quotes