### PR TITLE
Guard against missing I18n translations

### DIFF
--- a/improve_typography.gemspec
+++ b/improve_typography.gemspec
@@ -24,9 +24,9 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'i18n'
   spec.add_dependency 'nokogiri'
 
-  spec.add_development_dependency 'bundler', '~> 1.12'
+  spec.add_development_dependency 'bundler', '~> 2.2'
   spec.add_development_dependency 'guard'
   spec.add_development_dependency 'guard-minitest'
   spec.add_development_dependency 'minitest', '~> 5.0'
-  spec.add_development_dependency 'rake', '~> 10.0'
+  spec.add_development_dependency 'rake', '~> 13.0'
 end

--- a/lib/config/locales/da.yml
+++ b/lib/config/locales/da.yml
@@ -1,0 +1,2 @@
+da:
+  foo: bar

--- a/lib/improve_typography/base.rb
+++ b/lib/improve_typography/base.rb
@@ -2,8 +2,20 @@ require 'nokogiri'
 
 module ImproveTypography
   class Base < Struct.new(:str, :options)
-    def self.call(*args)
-      new(*args).call
+    class << self
+      def all_processor_classes
+        @@all_processor_classes ||= []
+      end
+
+      def add_processor_class(klass)
+        unless all_processor_classes.include?(klass)
+          all_processor_classes << klass
+        end
+      end
+
+      def call(*args)
+        new(*args).call
+      end
     end
 
     def initialize(str, options = {})
@@ -41,7 +53,7 @@ module ImproveTypography
     end
 
     def all_processor_classes
-      @all_processor_classes ||= ObjectSpace.each_object(Class).select { |klass| klass < Processor }
+      self.class.all_processor_classes
     end
 
     def processor_for_locale(klass)

--- a/lib/improve_typography/processor.rb
+++ b/lib/improve_typography/processor.rb
@@ -21,6 +21,14 @@ module ImproveTypography
 
     private
 
+    def translation(key)
+      I18n.t(key, scope: %i(improve_typography), locale: locale)
+    end
+
+    def sign_exists?(sign)
+      !sign.nil? && !sign.match?(/translation missing/)
+    end
+
     def configuration
       @configuration ||= Configuration.new
     end

--- a/lib/improve_typography/processor.rb
+++ b/lib/improve_typography/processor.rb
@@ -1,7 +1,14 @@
 module ImproveTypography
   class Processor < Struct.new(:str, :options)
-    def self.call(*args)
-      new(*args).call
+    class << self
+      def call(*args)
+        new(*args).call
+      end
+
+      def inherited(klass)
+        ImproveTypography::Base.add_processor_class(klass)
+        super
+      end
     end
 
     def initialize(str, options = {})

--- a/lib/improve_typography/processors/apostrophe.rb
+++ b/lib/improve_typography/processors/apostrophe.rb
@@ -4,6 +4,7 @@ module ImproveTypography
       REGEXP = /(\w+)'(\w*)/i
 
       def call
+        return str unless sign_exists?(apostrophe_sign)
         return str unless str.match?(/'/)
         replace_apostrophe
       end
@@ -15,7 +16,7 @@ module ImproveTypography
       end
 
       def apostrophe_sign
-        options.fetch(:apostrophe_sign, I18n.t(:apostrophe_sign, scope: %i(improve_typography), locale: locale))
+        options.fetch(:apostrophe_sign, translation(:apostrophe_sign))
       end
     end
   end

--- a/lib/improve_typography/processors/double_quotes.rb
+++ b/lib/improve_typography/processors/double_quotes.rb
@@ -2,6 +2,7 @@ module ImproveTypography
   module Processors
     class DoubleQuotes < Processor
       def call
+        return str unless sign_exists?(double_quotes)
         return str unless str.match?(/[\"#{double_quotes[0]}#{double_quotes[1]}]/)
         replace_double_quotes
       end
@@ -17,7 +18,7 @@ module ImproveTypography
       end
 
       def double_quotes
-        options.fetch(:double_quotes, I18n.t(:double_quotes, scope: %i(improve_typography), locale: locale))
+        options.fetch(:double_quotes, translation(:double_quotes))
       end
     end
   end

--- a/lib/improve_typography/processors/ellipsis.rb
+++ b/lib/improve_typography/processors/ellipsis.rb
@@ -4,7 +4,7 @@ module ImproveTypography
       REGEXP = /(\.\s*?){3,}/i
 
       def call
-        return str unless ellipsis_sign
+        return str unless sign_exists?(ellipsis_sign)
         return str unless str.match?(REGEXP)
 
         str.gsub(REGEXP, ellipsis_sign)
@@ -13,7 +13,7 @@ module ImproveTypography
       private
 
       def ellipsis_sign
-        options.fetch(:ellipsis_sign, I18n.t(:ellipsis_sign, scope: %i(improve_typography), locale: locale))
+        options.fetch(:ellipsis_sign, translation(:ellipsis_sign))
       end
     end
   end

--- a/lib/improve_typography/processors/em_dash.rb
+++ b/lib/improve_typography/processors/em_dash.rb
@@ -4,6 +4,7 @@ module ImproveTypography
       REGEXP = /(\w+?)\s+-{1,3}\s+(\w+?)/i
 
       def call
+        return str unless sign_exists?(em_dash_sign)
         return str unless str.match?(/-{1,3}/)
         str.gsub(REGEXP, '\1'+em_dash_sign+'\2')
       end
@@ -11,7 +12,7 @@ module ImproveTypography
       private
 
       def em_dash_sign
-        options.fetch(:em_dash_sign, I18n.t(:em_dash_sign, scope: %i(improve_typography), locale: locale))
+        options.fetch(:em_dash_sign, translation(:em_dash_sign))
       end
     end
   end

--- a/lib/improve_typography/processors/en_dash.rb
+++ b/lib/improve_typography/processors/en_dash.rb
@@ -4,6 +4,7 @@ module ImproveTypography
       REGEXP = /(\w+?)\s+-{1,2}\s+(\w+?)/i
 
       def call
+        return str unless sign_exists?(en_dash_sign)
         return str unless str.match?(/-{1,3}/)
         str.gsub(REGEXP, '\1'+en_dash_sign+'\2')
       end
@@ -11,7 +12,7 @@ module ImproveTypography
       private
 
       def en_dash_sign
-        options.fetch(:en_dash_sign, I18n.t(:en_dash_sign, scope: %i(improve_typography), locale: locale))
+        options.fetch(:en_dash_sign, translation(:en_dash_sign))
       end
     end
   end

--- a/lib/improve_typography/processors/multiply_sign.rb
+++ b/lib/improve_typography/processors/multiply_sign.rb
@@ -4,7 +4,7 @@ module ImproveTypography
       REGEXP = /(\d+|[½⅓¼⅔⅛⅜⅝⅞])(\s*)x(\s*)(\d+|[½⅓¼⅔⅛⅜⅝⅞])/i
 
       def call
-        return str unless multiply_sign
+        return str unless sign_exists?(multiply_sign)
         return str unless str.match?(REGEXP)
 
         str.gsub(REGEXP, '\1'+multiply_sign+'\4')
@@ -13,7 +13,7 @@ module ImproveTypography
       private
 
       def multiply_sign
-        options.fetch(:multiply_sign, I18n.t(:multiply_sign, scope: %i(improve_typography), locale: locale))
+        options.fetch(:multiply_sign, translation(:multiply_sign))
       end
     end
   end

--- a/lib/improve_typography/processors/single_quotes.rb
+++ b/lib/improve_typography/processors/single_quotes.rb
@@ -2,6 +2,7 @@ module ImproveTypography
   module Processors
     class SingleQuotes < Processor
       def call
+        return str unless sign_exists?(single_quotes)
         return str unless str.match?(/[\'#{single_quotes[0]}#{single_quotes[1]}]/)
         replace_single_quotes
       end
@@ -17,7 +18,7 @@ module ImproveTypography
       end
 
       def single_quotes
-        options.fetch(:single_quotes, I18n.t(:single_quotes, scope: %i(improve_typography), locale: locale))
+        options.fetch(:single_quotes, translation(:single_quotes))
       end
     end
   end

--- a/test/improve_typography/base_test.rb
+++ b/test/improve_typography/base_test.rb
@@ -11,7 +11,7 @@ describe ImproveTypography::Base do
   let(:en_dash_sign_with_nbsp) { en_dash_sign.gsub(' ', '&nbsp;') }
 
   describe 'default locale' do
-    it { result.must_equal "#{single_quotes[0]}So it isn#{apostrophe_sign}t authorless#{single_quotes[1]}. Maybe#{ellipsis_sign} Or 2#{en_dash_sign_with_nbsp}4?" }
+    it { _(result).must_equal "#{single_quotes[0]}So it isn#{apostrophe_sign}t authorless#{single_quotes[1]}. Maybe#{ellipsis_sign} Or 2#{en_dash_sign_with_nbsp}4?" }
   end
 
   describe 'locale' do
@@ -21,19 +21,19 @@ describe ImproveTypography::Base do
     describe 'local' do
       let(:result) { ImproveTypography::Base.call(text, locale: locale) }
 
-      it { result.must_equal "#{single_quotes[0]}So it isn#{apostrophe_sign}t authorless#{single_quotes[1]}. Maybe#{ellipsis_sign} Or 2#{en_dash_sign_with_nbsp}4?" }
+      it { _(result).must_equal "#{single_quotes[0]}So it isn#{apostrophe_sign}t authorless#{single_quotes[1]}. Maybe#{ellipsis_sign} Or 2#{en_dash_sign_with_nbsp}4?" }
     end
 
     describe 'global' do
       before { I18n.locale = locale }
       after { I18n.locale = I18n.default_locale }
 
-      it { result.must_equal "‚So it isn’t authorless‘. Maybe… Or 2&nbsp;–&nbsp;4?" }
+      it { _(result).must_equal "‚So it isn’t authorless‘. Maybe… Or 2&nbsp;–&nbsp;4?" }
     end
   end
 
   describe 'skips tags' do
     let(:text) { '<span class="foo" data-value="3">2 -- 4</span>' }
-    it { result.must_equal '<span class="foo" data-value="3">2&nbsp;–&nbsp;4</span>' }
+    it { _(result).must_equal '<span class="foo" data-value="3">2&nbsp;–&nbsp;4</span>' }
   end
 end

--- a/test/improve_typography/base_test.rb
+++ b/test/improve_typography/base_test.rb
@@ -36,4 +36,8 @@ describe ImproveTypography::Base do
     let(:text) { '<span class="foo" data-value="3">2 -- 4</span>' }
     it { _(result).must_equal '<span class="foo" data-value="3">2&nbsp;–&nbsp;4</span>' }
   end
+
+  it "doesnt mess up danish" do
+    _(ImproveTypography::Base.call("Ebeltoft", locale: :da)).must_equal "Ebeltoft"
+  end
 end

--- a/test/improve_typography/processors/apostrophe_test.rb
+++ b/test/improve_typography/processors/apostrophe_test.rb
@@ -6,9 +6,9 @@ module ImproveTypography
       let(:apostrophe_sign) { I18n.t :apostrophe_sign, scope: %i(improve_typography) }
 
       describe "do's" do
-        it { Apostrophe.call("isn't").must_equal "isn#{apostrophe_sign}t" }
-        it { Apostrophe.call("Tomas'").must_equal "Tomas#{apostrophe_sign}" }
-        it { Apostrophe.call("Tomas'!").must_equal "Tomas#{apostrophe_sign}!" }
+        it { _(Apostrophe.call("isn't")).must_equal "isn#{apostrophe_sign}t" }
+        it { _(Apostrophe.call("Tomas'")).must_equal "Tomas#{apostrophe_sign}" }
+        it { _(Apostrophe.call("Tomas'!")).must_equal "Tomas#{apostrophe_sign}!" }
       end
 
       describe "dont's" do

--- a/test/improve_typography/processors/apostrophe_test.rb
+++ b/test/improve_typography/processors/apostrophe_test.rb
@@ -12,6 +12,7 @@ module ImproveTypography
       end
 
       describe "dont's" do
+        it { _(Apostrophe.call("isn't", locale: :da)).must_equal "isn't" }
       end
     end
   end

--- a/test/improve_typography/processors/double_quotes_test.rb
+++ b/test/improve_typography/processors/double_quotes_test.rb
@@ -14,6 +14,7 @@ module ImproveTypography
       end
 
       describe "dont's" do
+        it { _(DoubleQuotes.call('"so it is not authorless"', locale: :da)).must_equal '"so it is not authorless"' }
       end
     end
   end

--- a/test/improve_typography/processors/double_quotes_test.rb
+++ b/test/improve_typography/processors/double_quotes_test.rb
@@ -6,11 +6,11 @@ module ImproveTypography
       let(:double_quotes) { I18n.t :double_quotes, scope: %i(improve_typography) }
 
       describe "do's" do
-        it { DoubleQuotes.call('"so it is not authorless"').must_equal "#{double_quotes[0]}so it is not authorless#{double_quotes[1]}" }
-        it { DoubleQuotes.call('"2 + 2 = 6"').must_equal "#{double_quotes[0]}2 + 2 = 6#{double_quotes[1]}" }
-        it { DoubleQuotes.call('"2 + 2 = 6" and "2 - 2 = 0"').must_equal "#{double_quotes[0]}2 + 2 = 6#{double_quotes[1]} and #{double_quotes[0]}2 - 2 = 0#{double_quotes[1]}" }
-        it { DoubleQuotes.call('“2 + 2 = 6” and ”2 - 2 = 0”').must_equal "#{double_quotes[0]}2 + 2 = 6#{double_quotes[1]} and #{double_quotes[0]}2 - 2 = 0#{double_quotes[1]}" }
-        it { DoubleQuotes.call('”2 + 2 = 6” and ”2 - 2 = 0”').must_equal "#{double_quotes[0]}2 + 2 = 6#{double_quotes[1]} and #{double_quotes[0]}2 - 2 = 0#{double_quotes[1]}" }
+        it { _(DoubleQuotes.call('"so it is not authorless"')).must_equal "#{double_quotes[0]}so it is not authorless#{double_quotes[1]}" }
+        it { _(DoubleQuotes.call('"2 + 2 = 6"')).must_equal "#{double_quotes[0]}2 + 2 = 6#{double_quotes[1]}" }
+        it { _(DoubleQuotes.call('"2 + 2 = 6" and "2 - 2 = 0"')).must_equal "#{double_quotes[0]}2 + 2 = 6#{double_quotes[1]} and #{double_quotes[0]}2 - 2 = 0#{double_quotes[1]}" }
+        it { _(DoubleQuotes.call('“2 + 2 = 6” and ”2 - 2 = 0”')).must_equal "#{double_quotes[0]}2 + 2 = 6#{double_quotes[1]} and #{double_quotes[0]}2 - 2 = 0#{double_quotes[1]}" }
+        it { _(DoubleQuotes.call('”2 + 2 = 6” and ”2 - 2 = 0”')).must_equal "#{double_quotes[0]}2 + 2 = 6#{double_quotes[1]} and #{double_quotes[0]}2 - 2 = 0#{double_quotes[1]}" }
       end
 
       describe "dont's" do

--- a/test/improve_typography/processors/ellipsis_test.rb
+++ b/test/improve_typography/processors/ellipsis_test.rb
@@ -15,6 +15,7 @@ module ImproveTypography
       end
 
       describe "dont's" do
+        it { _(Ellipsis.call('...', locale: :da)).must_equal '...' }
         it { _(Ellipsis.call('Some.')).must_equal 'Some.' }
         it { _(Ellipsis.call('2..5')).must_equal '2..5' }
       end

--- a/test/improve_typography/processors/ellipsis_test.rb
+++ b/test/improve_typography/processors/ellipsis_test.rb
@@ -6,17 +6,17 @@ module ImproveTypography
       let(:ellipsis_sign) { I18n.t :ellipsis_sign, scope: %i(improve_typography) }
 
       describe "do's" do
-        it { Ellipsis.call('...').must_equal ellipsis_sign }
-        it { Ellipsis.call('......').must_equal ellipsis_sign }
+        it { _(Ellipsis.call('...')).must_equal ellipsis_sign }
+        it { _(Ellipsis.call('......')).must_equal ellipsis_sign }
 
-        it { Ellipsis.call('Someday...').must_equal "Someday#{ellipsis_sign}" }
-        it { Ellipsis.call('Someday ...').must_equal "Someday #{ellipsis_sign}" }
-        it { Ellipsis.call('something . . . if this').must_equal "something #{ellipsis_sign} if this" }
+        it { _(Ellipsis.call('Someday...')).must_equal "Someday#{ellipsis_sign}" }
+        it { _(Ellipsis.call('Someday ...')).must_equal "Someday #{ellipsis_sign}" }
+        it { _(Ellipsis.call('something . . . if this')).must_equal "something #{ellipsis_sign} if this" }
       end
 
       describe "dont's" do
-        it { Ellipsis.call('Some.').must_equal 'Some.' }
-        it { Ellipsis.call('2..5').must_equal '2..5' }
+        it { _(Ellipsis.call('Some.')).must_equal 'Some.' }
+        it { _(Ellipsis.call('2..5')).must_equal '2..5' }
       end
     end
   end

--- a/test/improve_typography/processors/em_dash_test.rb
+++ b/test/improve_typography/processors/em_dash_test.rb
@@ -6,18 +6,18 @@ module ImproveTypography
       let(:em_dash_sign) { I18n.t :em_dash_sign, scope: %i(improve_typography) }
 
       describe "do's" do
-        it { EmDash.call('you - me').must_equal "you#{em_dash_sign}me" }
-        it { EmDash.call('insert - sentence - here').must_equal "insert#{em_dash_sign}sentence#{em_dash_sign}here" }
+        it { _(EmDash.call('you - me')).must_equal "you#{em_dash_sign}me" }
+        it { _(EmDash.call('insert - sentence - here')).must_equal "insert#{em_dash_sign}sentence#{em_dash_sign}here" }
 
-        it { EmDash.call('you -- me').must_equal "you#{em_dash_sign}me" }
-        it { EmDash.call('insert -- sentence -- here').must_equal "insert#{em_dash_sign}sentence#{em_dash_sign}here" }
+        it { _(EmDash.call('you -- me')).must_equal "you#{em_dash_sign}me" }
+        it { _(EmDash.call('insert -- sentence -- here')).must_equal "insert#{em_dash_sign}sentence#{em_dash_sign}here" }
 
-        it { EmDash.call('insert --- sentence').must_equal "insert#{em_dash_sign}sentence" }
+        it { _(EmDash.call('insert --- sentence')).must_equal "insert#{em_dash_sign}sentence" }
       end
 
       describe "options" do
         let(:em_dash_sign) { ' – ' }
-        it { EmDash.call('you - me', em_dash_sign: em_dash_sign).must_equal "you#{em_dash_sign}me" }
+        it { _(EmDash.call('you - me', em_dash_sign: em_dash_sign)).must_equal "you#{em_dash_sign}me" }
       end
 
       describe "dont's" do

--- a/test/improve_typography/processors/em_dash_test.rb
+++ b/test/improve_typography/processors/em_dash_test.rb
@@ -21,7 +21,7 @@ module ImproveTypography
       end
 
       describe "dont's" do
-        # it { EmDash.call('2-5').wont_equal '2-5' }
+        it { _(EmDash.call('you - me', locale: :da)).must_equal 'you - me' }
       end
     end
   end

--- a/test/improve_typography/processors/en_dash_test.rb
+++ b/test/improve_typography/processors/en_dash_test.rb
@@ -6,13 +6,13 @@ module ImproveTypography
       let(:en_dash_sign) { I18n.t :en_dash_sign, scope: %i(improve_typography) }
 
       describe "do's" do
-        it { EnDash.call('June 15 - June 20').must_equal "June 15#{en_dash_sign}June 20" }
-        it { EnDash.call('19/6/2016 - 30/10/2016').must_equal "19/6/2016#{en_dash_sign}30/10/2016" }
-        it { EnDash.call('A -- B').must_equal "A#{en_dash_sign}B" }
+        it { _(EnDash.call('June 15 - June 20')).must_equal "June 15#{en_dash_sign}June 20" }
+        it { _(EnDash.call('19/6/2016 - 30/10/2016')).must_equal "19/6/2016#{en_dash_sign}30/10/2016" }
+        it { _(EnDash.call('A -- B')).must_equal "A#{en_dash_sign}B" }
       end
 
       describe "dont's" do
-        it { EnDash.call('2-5').must_equal '2-5' }
+        it { _(EnDash.call('2-5')).must_equal '2-5' }
       end
     end
   end

--- a/test/improve_typography/processors/en_dash_test.rb
+++ b/test/improve_typography/processors/en_dash_test.rb
@@ -13,6 +13,7 @@ module ImproveTypography
 
       describe "dont's" do
         it { _(EnDash.call('2-5')).must_equal '2-5' }
+        it { _(EnDash.call('June 15 - June 20', locale: :da)).must_equal 'June 15 - June 20' }
       end
     end
   end

--- a/test/improve_typography/processors/multiply_sign_test.rb
+++ b/test/improve_typography/processors/multiply_sign_test.rb
@@ -6,21 +6,21 @@ module ImproveTypography
       let(:multiply_sign) { I18n.t :multiply_sign, scope: %i(improve_typography) }
 
       describe "do's" do
-        it { MultiplySign.call('2x10').must_equal "2#{multiply_sign}10" }
-        it { MultiplySign.call('2 x 10').must_equal "2#{multiply_sign}10" }
-        it { MultiplySign.call('a 200x1 b').must_equal "a 200#{multiply_sign}1 b" }
-        it { MultiplySign.call('25,6 x 17.9').must_equal "25,6#{multiply_sign}17.9" }
-        it { MultiplySign.call('½ x ½').must_equal "½#{multiply_sign}½" }
+        it { _(MultiplySign.call('2x10')).must_equal "2#{multiply_sign}10" }
+        it { _(MultiplySign.call('2 x 10')).must_equal "2#{multiply_sign}10" }
+        it { _(MultiplySign.call('a 200x1 b')).must_equal "a 200#{multiply_sign}1 b" }
+        it { _(MultiplySign.call('25,6 x 17.9')).must_equal "25,6#{multiply_sign}17.9" }
+        it { _(MultiplySign.call('½ x ½')).must_equal "½#{multiply_sign}½" }
       end
 
       describe "options" do
         let(:multiply_sign) { '×' }
-        it { MultiplySign.call('2x10', multiply_sign: multiply_sign).must_equal "2#{multiply_sign}10" }
+        it { _(MultiplySign.call('2x10', multiply_sign: multiply_sign)).must_equal "2#{multiply_sign}10" }
       end
 
       describe "dont's" do
-        it { MultiplySign.call('x + y').must_equal 'x + y' }
-        it { MultiplySign.call('mexico').must_equal 'mexico' }
+        it { _(MultiplySign.call('x + y')).must_equal 'x + y' }
+        it { _(MultiplySign.call('mexico')).must_equal 'mexico' }
       end
     end
   end

--- a/test/improve_typography/processors/nbsp_test.rb
+++ b/test/improve_typography/processors/nbsp_test.rb
@@ -4,22 +4,22 @@ module ImproveTypography
   module Processors
     describe Nbsp do
       describe "do's" do
-        it { Nbsp.call('and interdependent, sharing a common time.').must_equal 'and interdependent, sharing a&nbsp;common time.' }
-        it { Nbsp.call('with 35 years of clips').must_equal 'with 35&nbsp;years of clips' }
-        it { Nbsp.call('Andrew W. Mellon').must_equal 'Andrew W.&nbsp;Mellon' }
-        it { Nbsp.call('Width 1').must_equal 'Width&nbsp;1' }
-        it { Nbsp.call('Width 1? Hmm').must_equal 'Width&nbsp;1? Hmm' }
-        it { Nbsp.call('1 Width').must_equal '1&nbsp;Width' }
-        it { Nbsp.call('Hmm. 1 Width').must_equal 'Hmm. 1&nbsp;Width' }
-        it { Nbsp.call('Title. © 2016').must_equal 'Title. ©&nbsp;2016' }
-        it { Nbsp.call('Title, Vol. 2').must_equal 'Title, Vol.&nbsp;2' }
-        it { Nbsp.call('Title, No. 3').must_equal 'Title, No.&nbsp;3' }
-        it { Nbsp.call('© 2002 Author').must_equal '©&nbsp;2002&nbsp;Author' }
+        it { _(Nbsp.call('and interdependent, sharing a common time.')).must_equal 'and interdependent, sharing a&nbsp;common time.' }
+        it { _(Nbsp.call('with 35 years of clips')).must_equal 'with 35&nbsp;years of clips' }
+        it { _(Nbsp.call('Andrew W. Mellon')).must_equal 'Andrew W.&nbsp;Mellon' }
+        it { _(Nbsp.call('Width 1')).must_equal 'Width&nbsp;1' }
+        it { _(Nbsp.call('Width 1? Hmm')).must_equal 'Width&nbsp;1? Hmm' }
+        it { _(Nbsp.call('1 Width')).must_equal '1&nbsp;Width' }
+        it { _(Nbsp.call('Hmm. 1 Width')).must_equal 'Hmm. 1&nbsp;Width' }
+        it { _(Nbsp.call('Title. © 2016')).must_equal 'Title. ©&nbsp;2016' }
+        it { _(Nbsp.call('Title, Vol. 2')).must_equal 'Title, Vol.&nbsp;2' }
+        it { _(Nbsp.call('Title, No. 3')).must_equal 'Title, No.&nbsp;3' }
+        it { _(Nbsp.call('© 2002 Author')).must_equal '©&nbsp;2002&nbsp;Author' }
       end
 
       describe "dont's" do
-        it { Nbsp.call("\n2009").wont_equal "&nbsp;2009" }
-        it { Nbsp.call(", (2009)").wont_equal ",&nbsp;(2009)" }
+        it { _(Nbsp.call("\n2009")).wont_equal "&nbsp;2009" }
+        it { _(Nbsp.call(", (2009)")).wont_equal ",&nbsp;(2009)" }
       end
     end
   end

--- a/test/improve_typography/processors/single_quotes_test.rb
+++ b/test/improve_typography/processors/single_quotes_test.rb
@@ -6,11 +6,11 @@ module ImproveTypography
       let(:single_quotes) { I18n.t :single_quotes, scope: %i(improve_typography) }
 
       describe "do's" do
-        it { SingleQuotes.call("'so it is not authorless'").must_equal "#{single_quotes[0]}so it is not authorless#{single_quotes[1]}" }
-        it { SingleQuotes.call("'so it isn't authorless' or 'it doesn't seem that way'").must_equal "#{single_quotes[0]}so it isn't authorless#{single_quotes[1]} or #{single_quotes[0]}it doesn't seem that way#{single_quotes[1]}" }
-        it { SingleQuotes.call("'2 + 2 = 6'").must_equal "#{single_quotes[0]}2 + 2 = 6#{single_quotes[1]}" }
-        it { SingleQuotes.call("’2 + 2 = 6’ and ’1 + 1 = 99’").must_equal "#{single_quotes[0]}2 + 2 = 6#{single_quotes[1]} and #{single_quotes[0]}1 + 1 = 99#{single_quotes[1]}" }
-        it { SingleQuotes.call("‘2 + 2 = 6‘ and ‘1 + 1 = 99‘").must_equal "#{single_quotes[0]}2 + 2 = 6#{single_quotes[1]} and #{single_quotes[0]}1 + 1 = 99#{single_quotes[1]}" }
+        it { _(SingleQuotes.call("'so it is not authorless'")).must_equal "#{single_quotes[0]}so it is not authorless#{single_quotes[1]}" }
+        it { _(SingleQuotes.call("'so it isn't authorless' or 'it doesn't seem that way'")).must_equal "#{single_quotes[0]}so it isn't authorless#{single_quotes[1]} or #{single_quotes[0]}it doesn't seem that way#{single_quotes[1]}" }
+        it { _(SingleQuotes.call("'2 + 2 = 6'")).must_equal "#{single_quotes[0]}2 + 2 = 6#{single_quotes[1]}" }
+        it { _(SingleQuotes.call("’2 + 2 = 6’ and ’1 + 1 = 99’")).must_equal "#{single_quotes[0]}2 + 2 = 6#{single_quotes[1]} and #{single_quotes[0]}1 + 1 = 99#{single_quotes[1]}" }
+        it { _(SingleQuotes.call("‘2 + 2 = 6‘ and ‘1 + 1 = 99‘")).must_equal "#{single_quotes[0]}2 + 2 = 6#{single_quotes[1]} and #{single_quotes[0]}1 + 1 = 99#{single_quotes[1]}" }
       end
 
       describe "dont's" do

--- a/test/improve_typography/processors/units_test.rb
+++ b/test/improve_typography/processors/units_test.rb
@@ -4,8 +4,8 @@ module ImproveTypography
   module Processors
     describe Units do
       describe "do's" do
-        it { Units.call('50 m2').must_equal '50 m<sup>2</sup>' }
-        it { Units.call('50 mm3').must_equal '50 mm<sup>3</sup>' }
+        it { _(Units.call('50 m2')).must_equal '50 m<sup>2</sup>' }
+        it { _(Units.call('50 mm3')).must_equal '50 mm<sup>3</sup>' }
       end
 
       describe "dont's" do

--- a/test/improve_typography/processors/word_line_separator_test.rb
+++ b/test/improve_typography/processors/word_line_separator_test.rb
@@ -4,7 +4,7 @@ module ImproveTypography
   module Processors
     describe WordLineSeparator do
       describe "do's" do
-        it { WordLineSeparator.call("We always begin with a conversation. Within the dialogue, one idea becomes many.").must_equal %{We always begin with a conversation.\nWithin the dialogue, one idea becomes many.} }
+        it { _(WordLineSeparator.call("We always begin with a conversation. Within the dialogue, one idea becomes many.")).must_equal %{We always begin with a conversation.\nWithin the dialogue, one idea becomes many.} }
       end
 
       describe "dont's" do


### PR DESCRIPTION
If a locale is missing the translations for signs, the output can get quite strange. This PR adds guards against this situation and simply returns the input unaltered.