### PR TITLE
Fix single quote capturing apostrophes

### DIFF
--- a/lib/improve_typography/processors/single_quotes.rb
+++ b/lib/improve_typography/processors/single_quotes.rb
@@ -3,18 +3,18 @@ module ImproveTypography
     class SingleQuotes < Processor
       def call
         return str unless sign_exists?(single_quotes)
-        return str unless str.match?(/[\'#{single_quotes[0]}#{single_quotes[1]}]/)
+        return str unless str.match?(regexp)
         replace_single_quotes
       end
 
       private
 
       def replace_single_quotes
-        str.gsub(regexp, "\\1#{single_quotes[0]}\\2#{single_quotes[1]}")
+        str.gsub(regexp, "#{single_quotes[0]}\\1#{single_quotes[1]}")
       end
 
       def regexp
-        @regexp ||= Regexp.new("(\\A|\\W)['#{single_quotes[0]}#{single_quotes[1]}](.*?)['#{single_quotes[0]}#{single_quotes[1]}](?!\\w)")
+        @regexp ||= Regexp.new("(?<=\\A|\\W)['#{single_quotes[0]}#{single_quotes[1]}](.*?)['#{single_quotes[0]}#{single_quotes[1]}](?!\\w)")
       end
 
       def single_quotes

--- a/lib/improve_typography/processors/single_quotes.rb
+++ b/lib/improve_typography/processors/single_quotes.rb
@@ -10,11 +10,11 @@ module ImproveTypography
       private
 
       def replace_single_quotes
-        str.gsub(regexp, "#{single_quotes[0]}\\1#{single_quotes[1]}")
+        str.gsub(regexp, "\\1#{single_quotes[0]}\\2#{single_quotes[1]}")
       end
 
       def regexp
-        @regexp ||= Regexp.new("['#{single_quotes[0]}#{single_quotes[1]}](.*?)['#{single_quotes[0]}#{single_quotes[1]}](?!\\w)")
+        @regexp ||= Regexp.new("(\\A|\\W)['#{single_quotes[0]}#{single_quotes[1]}](.*?)['#{single_quotes[0]}#{single_quotes[1]}](?!\\w)")
       end
 
       def single_quotes

--- a/test/improve_typography/processors/single_quotes_test.rb
+++ b/test/improve_typography/processors/single_quotes_test.rb
@@ -14,6 +14,7 @@ module ImproveTypography
       end
 
       describe "dont's" do
+        it { _(SingleQuotes.call("Serbia's workers' society")).must_equal "Serbia's workers' society" }
       end
     end
   end


### PR DESCRIPTION
The `SingleQuotes` processor would incorrectly replace the apostrophes in `Serbia's workers' society`.

This PR fixes the regex and gsub call so that it doesn't capture this case.